### PR TITLE
update ssl-wrapping method to use specific ssl context and set cyphers

### DIFF
--- a/OMMClient/OMMClient.py
+++ b/OMMClient/OMMClient.py
@@ -45,7 +45,8 @@ class OMMClient(Events):
         self._port = port
         self._tcp_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self._tcp_socket.settimeout(10)
-        self._ssl_context = ssl.create_default_context()
+        self._ssl_context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLSv1_2)
+        self._ssl_context.set_ciphers("AES256-GCM-SHA384")
         self._ssl_socket = self._ssl_context.wrap_socket(self._tcp_socket, server_hostname=self._host)
         self._send_q = queue.Queue()  # should contains strings (not bytes)
         self._recv_q = queue.Queue()  # should contains strings (not bytes)

--- a/OMMClient/OMMClient.py
+++ b/OMMClient/OMMClient.py
@@ -45,7 +45,8 @@ class OMMClient(Events):
         self._port = port
         self._tcp_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self._tcp_socket.settimeout(10)
-        self._ssl_socket = ssl.wrap_socket(self._tcp_socket)
+        self._ssl_context = ssl.create_default_context()
+        self._ssl_socket = self._ssl_context.wrap_socket(self._tcp_socket, server_hostname=self._host)
         self._send_q = queue.Queue()  # should contains strings (not bytes)
         self._recv_q = queue.Queue()  # should contains strings (not bytes)
         self._worker = Thread(target=self._work)

--- a/OMMClient/utils.py
+++ b/OMMClient/utils.py
@@ -8,8 +8,8 @@ def encrypt_pin(pin, modulus, exponent):
     # Quote from https://stackoverflow.com/questions/2855326
     # Necessary for OMM to compare PIN of a user
     pub_key = rsa.PublicKey(int(modulus, 16), int(exponent, 16))
-    crypted = rsa.encrypt(pin, pub_key=pub_key)
-    return base64.b64encode(crypted)
+    crypted = rsa.encrypt(pin.encode('utf-8'), pub_key=pub_key)
+    return base64.b64encode(crypted).decode('utf-8')
 
 
 def convert_ipui(ipui):


### PR DESCRIPTION
with up-to-date python and openssl versions, i was not able to connect to the omm. Troubleshooting using Wireshark, i found out, my laptop with older versions would connect but my desktop computer does not use RAS cypers anymore thereby getting an ssl handshake error.
To prevent that issue in future i updated the section in OMMClient that wraps the tcp connection in ssl. 
Python's ssl module now creates a context that is set to use TLSv1.2. Then the context's cypher is set to specifically use AES256-GCM-SHA384 cypher. The context's wrap function then wraps the tcp connection.